### PR TITLE
feat(ui): UI shell with stubs (Electron+React)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,9 +1,5 @@
 import { app, BrowserWindow } from 'electron';
-import { fileURLToPath } from 'node:url';
-import { join, dirname } from 'node:path';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import { join } from 'node:path';
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -36,4 +32,3 @@ app.whenReady().then(() => {
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();
 });
-

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,0 +1,39 @@
+import { app, BrowserWindow } from 'electron';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    webPreferences: {
+      preload: join(__dirname, 'preload.js'),
+      nodeIntegration: false,
+      contextIsolation: true,
+    },
+  });
+
+  const isDev = !!process.env.VITE_DEV;
+  if (isDev) {
+    win.loadURL('http://localhost:5173');
+  } else {
+    const indexHtml = join(process.cwd(), 'ui', 'dist', 'index.html');
+    win.loadFile(indexHtml);
+  }
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});
+

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,0 +1,10 @@
+import { contextBridge } from 'electron';
+
+contextBridge.exposeInMainWorld('appBridge', {
+  versions: {
+    node: process.versions.node,
+    chrome: process.versions.chrome,
+    electron: process.versions.electron,
+  },
+});
+

--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "../dist",
+    "rootDir": ".",
+    "moduleResolution": "Node",
+    "types": ["node"],
+    "target": "ES2020"
+  },
+  "include": ["./*.ts"]
+}
+

--- a/package.json
+++ b/package.json
@@ -2,13 +2,32 @@
   "name": "evm-tool-starter",
   "version": "0.1.0",
   "private": true,
+  "main": "dist/main.js",
   "scripts": {
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "dev": "concurrently -k \"vite --config ui/vite.config.ts\" \"wait-on tcp:5173 && cross-env VITE_DEV=1 electron .\"",
+    "build:renderer": "vite build --config ui/vite.config.ts",
+    "build:electron": "electron-builder -c.extraMetadata.main=dist/main.js",
+    "build": "npm run build:renderer && tsc -p electron && npm run build:electron",
+    "test:ui": "vitest --config ui/vite.config.ts --run"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.8",
+    "@testing-library/react": "^16.0.0",
+    "@types/node": "^20.14.10",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "concurrently": "^8.2.2",
+    "cross-env": "^7.0.3",
+    "electron": "^30.0.9",
+    "electron-builder": "^24.13.3",
+    "jsdom": "^24.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "typescript": "^5.4.0",
-    "vitest": "^2.0.0"
+    "vite": "^5.3.1",
+    "vitest": "^2.0.0",
+    "wait-on": "^7.2.0"
   }
 }
-

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,0 +1,2 @@
+export * from './sprint2-shims'
+

--- a/src/adapters/sprint2-shims.ts
+++ b/src/adapters/sprint2-shims.ts
@@ -1,0 +1,86 @@
+// Sprint2 shims: keep the same interface so UI can switch later.
+
+export type GanttCfg = { pxPerDay: number }
+
+export function buildTripleHeader(startISO: string, endISO: string, cfg: GanttCfg) {
+  const start = new Date(startISO)
+  const end = new Date(endISO)
+  const days = Math.max(1, Math.ceil((+end - +start) / 86400000))
+  const segments = Array.from({ length: days }, (_, i) => {
+    const d = new Date(start)
+    d.setDate(start.getDate() + i)
+    const x = i * cfg.pxPerDay
+    return {
+      date: d.toISOString().slice(0, 10),
+      x,
+      w: cfg.pxPerDay,
+      ym: `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`,
+      day: String(d.getDate()).padStart(2, '0'),
+      weekday: ['日','月','火','水','木','金','土'][d.getDay()],
+    }
+  })
+
+  // group by ym
+  const ymMap = new Map<string, { label: string; x: number; w: number }>()
+  segments.forEach((s) => {
+    const g = ymMap.get(s.ym)
+    if (!g) ymMap.set(s.ym, { label: s.ym, x: s.x, w: s.w })
+    else g.w += s.w
+  })
+
+  return {
+    yearMonth: Array.from(ymMap.values()),
+    day: segments.map((s) => ({ label: s.day, x: s.x, w: s.w })),
+    weekday: segments.map((s) => ({ label: s.weekday, x: s.x, w: s.w })),
+  }
+}
+
+export function dateToX(dateISO: string, chartStartISO: string, cfg: GanttCfg) {
+  const d = new Date(dateISO)
+  const s = new Date(chartStartISO)
+  const diffDays = Math.floor((+d - +s) / 86400000)
+  return Math.max(0, diffDays * cfg.pxPerDay)
+}
+
+export function xToDate(x: number, chartStartISO: string, cfg: GanttCfg) {
+  const s = new Date(chartStartISO)
+  const days = Math.max(0, Math.round(x / cfg.pxPerDay))
+  const d = new Date(s)
+  d.setDate(s.getDate() + days)
+  return d.toISOString().slice(0, 10)
+}
+
+type Task = { id: string; name: string; start: string; end: string; progress: number }
+
+export function planBar(task: Task, chartStartISO: string, cfg: GanttCfg) {
+  const x = dateToX(task.start, chartStartISO, cfg)
+  const w = Math.max(cfg.pxPerDay, dateToX(task.end, chartStartISO, cfg) - x)
+  return { x, w }
+}
+
+export function actualBar(task: Task, chartStartISO: string, cfg: GanttCfg) {
+  const planned = planBar(task, chartStartISO, cfg)
+  const w = Math.max(4, Math.round(planned.w * Math.min(1, Math.max(0, task.progress))))
+  return { x: planned.x, w }
+}
+
+export function buildTaskTable(tasks: Task[]) {
+  return tasks.map((t) => ({ name: t.name, start: t.start, end: t.end, progress: Math.round(t.progress * 100) }))
+}
+
+export function formatJPY(n: number) {
+  return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY', maximumFractionDigits: 0 }).format(n)
+}
+
+export function computeEvmStub(tasks: Task[]) {
+  // simple fixed/dummy computation preserving interface
+  const PV = 1_000_000
+  const EV = 800_000
+  const AC = 900_000
+  const SV = EV - PV
+  const CV = EV - AC
+  const SPI = PV ? EV / PV : 0
+  const CPI = AC ? EV / AC : 0
+  return { PV, EV, AC, SV, CV, SPI, CPI }
+}
+

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EVM Tool UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+  </html>
+

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import GanttCanvas from './components/GanttCanvas'
+import TaskTable from './components/TaskTable'
+import EvmCard from './components/EvmCard'
+
+export default function App() {
+  return (
+    <div className="app-grid">
+      <header className="header">
+        <h1>EVM Tool UI Shell</h1>
+      </header>
+      <section className="gantt">
+        <GanttCanvas />
+      </section>
+      <section className="tasks">
+        <TaskTable />
+      </section>
+      <aside className="evm">
+        <EvmCard />
+      </aside>
+    </div>
+  )
+}
+

--- a/ui/src/components/EvmCard.tsx
+++ b/ui/src/components/EvmCard.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { computeEvmStub, formatJPY } from '../../../src/adapters'
+
+const tasks = [
+  { id: 'T1', name: '企画', start: '2024-01-01', end: '2024-01-05', progress: 0.6 },
+  { id: 'T2', name: '設計', start: '2024-01-03', end: '2024-01-10', progress: 0.3 },
+]
+
+export default function EvmCard() {
+  const evm = computeEvmStub(tasks as any)
+  const items: Array<[string, string]> = [
+    ['PV', formatJPY(evm.PV)],
+    ['EV', formatJPY(evm.EV)],
+    ['AC', formatJPY(evm.AC)],
+    ['SV', formatJPY(evm.SV)],
+    ['CV', formatJPY(evm.CV)],
+    ['SPI', evm.SPI.toFixed(2)],
+    ['CPI', evm.CPI.toFixed(2)],
+  ]
+
+  return (
+    <div className="card">
+      <div className="panel-title">EVM（ダミー）</div>
+      <div className="evm-grid">
+        {items.map(([k, v]) => (
+          <div key={k} className="evm-item">
+            <div className="evm-label">{k}</div>
+            <div className="evm-value">{v}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+

--- a/ui/src/components/GanttCanvas.tsx
+++ b/ui/src/components/GanttCanvas.tsx
@@ -17,7 +17,8 @@ export default function GanttCanvas() {
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
-    const ctx = canvas.getContext('2d')!
+    const ctx = canvas.getContext?.('2d') as CanvasRenderingContext2D | null
+    if (!ctx) return
     const width = 900
     const headerHeight = 60
     const rowH = 28
@@ -77,4 +78,3 @@ export default function GanttCanvas() {
 
 // Exported only for unit tests
 export const __test = { dateToX }
-

--- a/ui/src/components/GanttCanvas.tsx
+++ b/ui/src/components/GanttCanvas.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useRef } from 'react'
+import { buildTripleHeader, dateToX, planBar, actualBar } from '../../../src/adapters'
+
+const dummyTasks = [
+  { id: 'T1', name: '企画', start: '2024-01-01', end: '2024-01-05', progress: 0.6 },
+  { id: 'T2', name: '設計', start: '2024-01-03', end: '2024-01-10', progress: 0.3 },
+  { id: 'T3', name: '実装', start: '2024-01-08', end: '2024-01-15', progress: 0.1 },
+]
+
+const cfg = { pxPerDay: 16 }
+const chartStart = '2023-12-30'
+const chartEnd = '2024-01-20'
+
+export default function GanttCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')!
+    const width = 900
+    const headerHeight = 60
+    const rowH = 28
+    const height = headerHeight + dummyTasks.length * rowH + 20
+    canvas.width = width
+    canvas.height = height
+
+    ctx.clearRect(0, 0, width, height)
+
+    // header
+    const header = buildTripleHeader(chartStart, chartEnd, cfg)
+    ctx.fillStyle = '#fafafa'
+    ctx.fillRect(0, 0, width, headerHeight)
+    ctx.strokeStyle = '#ddd'
+    ctx.strokeRect(0, 0, width, headerHeight)
+
+    ctx.fillStyle = '#333'
+    ctx.font = '12px sans-serif'
+    let y = 14
+    ;['yearMonth', 'day', 'weekday'].forEach((level) => {
+      const segments = (header as any)[level] as Array<{ label: string; x: number; w: number }>
+      segments.forEach((s) => {
+        ctx.fillText(s.label, s.x + 4, y)
+        ctx.strokeStyle = '#eee'
+        ctx.strokeRect(s.x, (y - 12) + (level === 'yearMonth' ? 0 : level === 'day' ? 16 : 32), s.w, 16)
+      })
+      y += 16
+    })
+
+    // rows + bars
+    dummyTasks.forEach((t, i) => {
+      const top = headerHeight + i * rowH
+      // plan (blue)
+      const p = planBar(t as any, chartStart, cfg)
+      ctx.fillStyle = '#4C78A8'
+      ctx.fillRect(p.x, top + 6, p.w, 10)
+      // actual (green) — short dummy
+      const a = actualBar(t as any, chartStart, cfg)
+      ctx.fillStyle = '#59A14F'
+      ctx.fillRect(a.x, top + 18, a.w, 6)
+      // row separator
+      ctx.strokeStyle = '#f0f0f0'
+      ctx.beginPath()
+      ctx.moveTo(0, top + rowH)
+      ctx.lineTo(width, top + rowH)
+      ctx.stroke()
+    })
+  }, [])
+
+  return (
+    <div>
+      <div className="panel-title">ガント（ダミー）</div>
+      <canvas ref={canvasRef} style={{ width: '100%', height: '240px' }} />
+    </div>
+  )
+}
+
+// Exported only for unit tests
+export const __test = { dateToX }
+

--- a/ui/src/components/GanttCanvas.tsx
+++ b/ui/src/components/GanttCanvas.tsx
@@ -17,7 +17,13 @@ export default function GanttCanvas() {
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
-    const ctx = canvas.getContext?.('2d') as CanvasRenderingContext2D | null
+    let ctx: CanvasRenderingContext2D | null = null
+    try {
+      ctx = canvas.getContext('2d') as CanvasRenderingContext2D | null
+    } catch {
+      // in jsdom, HTMLCanvasElement.getContext is not implemented
+      return
+    }
     if (!ctx) return
     const width = 900
     const headerHeight = 60

--- a/ui/src/components/TaskTable.tsx
+++ b/ui/src/components/TaskTable.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+
+const tasks = [
+  { id: 'T1', name: '企画', start: '2024-01-01', end: '2024-01-05', progress: 60 },
+  { id: 'T2', name: '設計', start: '2024-01-03', end: '2024-01-10', progress: 30 },
+  { id: 'T3', name: '実装', start: '2024-01-08', end: '2024-01-15', progress: 10 },
+]
+
+export default function TaskTable() {
+  return (
+    <div>
+      <div className="panel-title">タスク一覧</div>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>名前</th>
+            <th>開始</th>
+            <th>終了</th>
+            <th>%</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tasks.map((t) => (
+            <tr key={t.id}>
+              <td>{t.name}</td>
+              <td>{t.start}</td>
+              <td>{t.end}</td>
+              <td style={{ textAlign: 'right' }}>{t.progress}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+import './styles.css'
+
+const container = document.getElementById('root')!
+const root = createRoot(container)
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)
+

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1,0 +1,26 @@
+:root { --bg: #ffffff; --border: #e5e5e5; --muted: #666; }
+html, body, #root { height: 100%; margin: 0; font-family: system-ui, sans-serif; background: var(--bg); }
+.app-grid {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  grid-template-rows: 56px auto;
+  grid-template-areas:
+    'header header'
+    'gantt evm'
+    'tasks evm';
+  gap: 12px;
+  padding: 12px;
+}
+.header { grid-area: header; border-bottom: 1px solid var(--border); display: flex; align-items: center; }
+.gantt { grid-area: gantt; border: 1px solid var(--border); border-radius: 6px; padding: 8px; background: #fff; }
+.tasks { grid-area: tasks; border: 1px solid var(--border); border-radius: 6px; padding: 8px; background: #fff; }
+.evm { grid-area: evm; border: 1px solid var(--border); border-radius: 6px; padding: 8px; background: #fff; }
+.panel-title { font-size: 12px; color: var(--muted); margin-bottom: 8px; }
+.table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.table th, .table td { border-bottom: 1px solid var(--border); padding: 6px 8px; }
+.card { display: flex; flex-direction: column; }
+.evm-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.evm-item { border: 1px dashed var(--border); border-radius: 6px; padding: 8px; }
+.evm-label { font-size: 12px; color: var(--muted); }
+.evm-value { font-weight: 600; }
+

--- a/ui/tests/App.snapshot.test.tsx
+++ b/ui/tests/App.snapshot.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import React from 'react'
+import App from '../src/App'
+
+describe('App snapshot', () => {
+  it('renders three panes', () => {
+    const { asFragment, getByText } = render(<App />)
+    expect(getByText('EVM Tool UI Shell')).toBeTruthy()
+    expect(getByText('ガント（ダミー）')).toBeTruthy()
+    expect(getByText('タスク一覧')).toBeTruthy()
+    expect(getByText('EVM（ダミー）')).toBeTruthy()
+    expect(asFragment()).toMatchSnapshot()
+  })
+})
+

--- a/ui/tests/GanttCanvas.unit.test.ts
+++ b/ui/tests/GanttCanvas.unit.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { __test } from '../src/components/GanttCanvas'
+
+describe('GanttCanvas helpers', () => {
+  it('dateToX returns non-negative for chart range', () => {
+    const cfg = { pxPerDay: 10 }
+    const x = __test.dateToX('2024-01-05', '2024-01-01', cfg as any)
+    expect(x).toBe(40)
+  })
+})
+

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true
+  },
+  "include": ["src"]
+}
+

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite'
+import path from 'node:path'
+
+export default defineConfig({
+  root: path.resolve(__dirname),
+  server: { port: 5173 },
+  build: { outDir: 'dist', emptyOutDir: true },
+  resolve: { alias: {} },
+  test: {
+    environment: 'jsdom',
+    setupFiles: [],
+    globals: true,
+    include: ['ui/tests/**/*.test.tsx'],
+  },
+})
+

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     setupFiles: [],
     globals: true,
     include: ['ui/tests/**/*.test.tsx'],
+    pool: 'threads',
+    maxThreads: 1,
   },
 })
-

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: [],
     globals: true,
-    include: ['ui/tests/**/*.test.tsx'],
+    include: ['tests/**/*.test.tsx'],
     pool: 'threads',
     maxThreads: 1,
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     include: ['tests/**/*.ts'],
     environment: 'node',
     exclude: ['ui/**'],
+    pool: 'threads',
+    maxThreads: 1,
   },
 })
-

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.ts'],
+    environment: 'node',
+    exclude: ['ui/**'],
+  },
+})
+


### PR DESCRIPTION
# UI Shell (Electron + React + Vite) — WIP

## 概要
- Electron + React + Vite の最小 UI シェルを追加
- シム／アダプタ層（`src/adapters/`）で Sprint2 の関数群を一時スタブ化
- 将来 `evm-mvp-sprint2/*` 取り込み後は import 先の差し替えのみで動作

## 追加内容
- Electron: `electron/main.ts`, `electron/preload.ts`, `electron/tsconfig.json`
- UI: `ui/index.html`, `ui/src/*`, `ui/vite.config.ts`, `ui/tsconfig.json`, `ui/src/styles.css`
- コンポーネント: `GanttCanvas.tsx`（ダミー三段ヘッダ＋バー）, `TaskTable.tsx`, `EvmCard.tsx`
- テスト: `ui/tests/App.snapshot.test.tsx`, `ui/tests/GanttCanvas.unit.test.ts`
- Adapters: `src/adapters/sprint2-shims.ts`, `src/adapters/index.ts`
- ルート test 設定: `vitest.config.ts`（既存 core テストの安定化）

## 動作確認
```bash
npm install
npm run dev   # 5173でVite→Electron起動、3ペイン表示
npm run build:renderer
npm run build # renderer + tsc + electron-builder
npm test      # 既存 core tests: pass
npm run test:ui  # UI tests: pass
